### PR TITLE
Open power dbus linking for clearing security keys

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -34,3 +34,8 @@ phosphor_settings_manager_LDADD = \
 	$(SDBUSPLUS_LIBS) \
         $(PHOSPHOR_LOGGING_LIBS) \
 	-lstdc++fs
+
+if LINK_OP_DBUS_INTFS
+phosphor_settings_manager_CXXFLAGS += $(OPENPOWER_DBUS_INTERFACES_CFLAGS)
+phosphor_settings_manager_LDADD += $(OPENPOWER_DBUS_INTERFACES_LIBS)
+endif

--- a/configure.ac
+++ b/configure.ac
@@ -22,6 +22,8 @@ AX_CXX_COMPILE_STDCXX_17([noext])
 AX_APPEND_COMPILE_FLAGS([-Wall -Werror], [CXXFLAGS])
 
 AC_ARG_VAR(SETTINGS_BUSNAME, [The Dbus busname to own])
+AS_IF([test "x$enable_link_op_dbus_intfs" = "xyes"],\
+    [PKG_CHECK_MODULES([OPENPOWER_DBUS_INTERFACES], [openpower-dbus-interfaces])])
 AS_IF([test "x$SETTINGS_BUSNAME" == "x"],\
     [SETTINGS_BUSNAME="xyz.openbmc_project.Settings"])
 AC_DEFINE_UNQUOTED([SETTINGS_BUSNAME], ["$SETTINGS_BUSNAME"],\
@@ -41,6 +43,13 @@ AC_DEFINE_UNQUOTED([SETTINGS_PERSIST_PATH], ["$SETTINGS_PERSIST_PATH"], \
 AC_ARG_VAR(CLASS_VERSION, [Class version to register with Cereal])
 AS_IF([test "x$CLASS_VERSION" == "x"], [CLASS_VERSION=1])
 AC_DEFINE_UNQUOTED([CLASS_VERSION], [$CLASS_VERSION], [Class version to register with Cereal])
+
+AC_ARG_ENABLE([link-op-dbus-intfs], AS_HELP_STRING([
+    --enable-link-op-dbus-intfs
+    ], [
+    Link with openpower-dbus-interfaces.
+]))
+AM_CONDITIONAL([LINK_OP_DBUS_INTFS], [test "x$enable_link_op_dbus_intfs" = "xyes"])
 
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT


### PR DESCRIPTION
A new property was added which can be used as a bit mask to indicate
clearing certain security keys or resetting those values back to its
default from the system by the host. This is to link the changes with
openpower-dbus-interfaces. Also provided a configure option to
enable/disable openpower dbus linking.

Tested: Verified that the property is getting created with the expected
default value as zero and can be updated to different values using ipmitool
or busctl command.

Default value output:
busctl get-property xyz.openbmc_project.Settings
/org/open_power/control/host0/ClearHostSecurityKeys
org.open_power.Control.TPM.SecurityKeys ClearHostSecurityKeys
y 0

ipmitool -I lanplus -H 9.3.185.33 -U root -P 0penBmc raw 0x04 0x2D 0xE8
00 40 00 00

Signed-off-by: Jayashankar Padath <jayashankar.padath@in.ibm.com>
Change-Id: I72120f9282291d07dc3f82ed7cec66fe7b1cde28